### PR TITLE
Ajustando loading infinito

### DIFF
--- a/middleware/guest.ts
+++ b/middleware/guest.ts
@@ -11,16 +11,23 @@ interface AuthState {
 
 export default function (context: Context) {
   const state = context.store.state as AuthState;
-  const decodedToken = decode(state.auth.token);
+  const decodedToken = decode(state.auth.token) as JwtPayload || null;
   if (checkExpire(decodedToken)) {
     context.redirect('/dashboard');
   }
 }
 
-function checkExpire (token: string | JwtPayload | null): boolean {
-  if (token) {
-    const { exp } = token as JwtPayload;
-    return (exp && exp < Date.now()) as boolean;
+function checkExpire (token: JwtPayload | null): boolean {
+  if (
+    token &&
+    token.exp
+  ) {
+    const { exp } = token;
+    const milisecond = exp * 1000;
+
+    if (milisecond < Date.now()) {
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
O loading infinito tinha relação com o fato do Date.now() do JS não retornar um número na mesma grandeza da data de expiração, sendo necessário multiplicar o token.exp por 1000 para igualar.
Não igualar esses valores fazia sempre o token.exp ser menor e com isso vue tenta redirecionar para uma tela não permitida, ocasionando um erro no JS.
Já alterei a função para seguir o padrão do auth.ts que está mais organizado.