### PR TITLE
Mapeando erro de ECONNREFUSED do redis e ajustando validação de token

### DIFF
--- a/middleware/guest.ts
+++ b/middleware/guest.ts
@@ -25,7 +25,7 @@ function checkExpire (token: JwtPayload | null): boolean {
     const { exp } = token;
     const milisecond = exp * 1000;
 
-    if (milisecond < Date.now()) {
+    if (milisecond > Date.now()) {
       return true;
     }
   }

--- a/plugins/axios.ts
+++ b/plugins/axios.ts
@@ -16,9 +16,12 @@ const api: Plugin = (context, inject) => {
       context.store.state.auth.user.role === 'administrator' &&
       error.response?.status === 500
     ) {
-      context.redirect('/queue');
-      alert('possivel erro no url do redis ou redis offline');
-      return Promise.resolve(error);
+      const erro = error.response.data?.error;
+      if (erro && erro.code === 'ECONNREFUSED') {
+        context.redirect('/queue');
+        alert('possivel erro no url do redis ou redis offline');
+        return Promise.resolve(error);
+      }
     }
 
     if (error.response?.status === 401) {


### PR DESCRIPTION
- Apenas redirecionando e exibindo alerta em status 500 quando o erro for de acesso ao redis, em outros casos mantem na mesma tela.
- Ajustando validação de token para quando ele estiver expirado.